### PR TITLE
[Part11] Use a lighter background highlight color

### DIFF
--- a/src/colors.json
+++ b/src/colors.json
@@ -13,5 +13,5 @@
   "light-blue": "#82D2F7",
   "light-violet": "#B2BBF0",
   "light-green": "#D4FCB5",
-  "smartly-purple": "#7d408c"
+  "smartly-purple": "#f8f5f9"
 }


### PR DESCRIPTION
- Use a light background color to make the tasks more legible.
- The final color will come from the university once the module is published.

---

**Before:**
![Fullstack part11 | Getting started with GitHub Actions 2020-10-20 10-31-34](https://user-images.githubusercontent.com/2010468/96554968-e1b94100-12bf-11eb-9b45-2f083fd82ece.png)

---

**After:**
![Fullstack part11 | Getting started with GitHub Actions 2020-10-20 10-35-11](https://user-images.githubusercontent.com/2010468/96555035-f39ae400-12bf-11eb-92d5-4783d4293290.png)
